### PR TITLE
fix: Workaround dns_get_record warning and check result

### DIFF
--- a/Services/Libravatar.php
+++ b/Services/Libravatar.php
@@ -422,12 +422,16 @@ class Services_Libravatar
             return $fallback . 'libravatar.org';
         }
 
-        // Lets try get us some records based on the choice of subdomain
+        // Let's try get us some records based on the choice of subdomain
         // and the domain we had passed in.
+        // Bug workaround: https://bugs.php.net/bug.php?id=73149
+        function NoWarnings($errno, $err_str, $err_file, $err_line){ return true; }
+        $old_handler = set_error_handler('NoWarnings', E_WARNING);
         $srv = dns_get_record($subdomain . $domain, DNS_SRV);
+        set_error_handler($old_handler, E_WARNING);
 
         // Did we get anything? No?
-        if (count($srv) == 0) {
+        if ($srv === false || count($srv) == 0) {
             // Then let's try Libravatar.org.
             return $fallback . 'libravatar.org';
         }

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,6 @@
     ],
     "type": "library",
     "require-dev": {
-        "phpunit/phpunit": "^5.7.0"
+        "phpunit/phpunit": "^11"
     }
 }

--- a/tests/Services/LibravatarTest.php
+++ b/tests/Services/LibravatarTest.php
@@ -440,7 +440,6 @@ class Services_LibravatarTest extends \PHPUnit\Framework\TestCase
             ->getMockBuilder('Services_Libravatar')
             ->onlyMethods(array('srvGet'))
             ->getMock();
-        //$this->sl = $this->getMock('Services_Libravatar', array('srvGet'));
         $this->sl->expects($this->once())
             ->method('srvGet')
             ->willReturn('example.org');

--- a/tests/Services/LibravatarTest.php
+++ b/tests/Services/LibravatarTest.php
@@ -1,10 +1,9 @@
 <?php
 require_once 'Services/Libravatar.php';
 
-class Services_LibravatarTest extends PHPUnit_Framework_TestCase
+class Services_LibravatarTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
-    {
+    public function setUp(): void {
         $this->sl = new Services_Libravatar();
     }
 
@@ -138,12 +137,10 @@ class Services_LibravatarTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Invalid option in array: foo
-     */
     public function testGetUrlOptionInvalid()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid option in array: foo');
         $this->sl->getUrl('cweiske@cweiske.de', array('foo' => 123));
     }
 
@@ -324,12 +321,10 @@ class Services_LibravatarTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('sha256', $this->getProtected('algorithm', $this->sl));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Only md5 and sha256 hashing supported
-     */
     public function testSetAlgorithmInvalid()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Only md5 and sha256 hashing supported');
         $this->sl->setAlgorithm('foo');
     }
 
@@ -356,21 +351,17 @@ class Services_LibravatarTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Invalid default avatar URL
-     */
     public function testSetDefaultInvalidShortcut()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid default avatar URL');
         $this->sl->setDefault('foo');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Invalid default avatar URL
-     */
     public function testSetDefaultInvalidUrl()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid default avatar URL');
         //missing protocol
         $this->sl->setDefault('example.org/default.png');
     }
@@ -393,12 +384,10 @@ class Services_LibravatarTest extends PHPUnit_Framework_TestCase
         $this->assertNull($this->getProtected('size', $this->sl));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Size has to be larger than 0
-     */
     public function testSetSizeInvalid()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Size has to be larger than 0');
         $this->sl->setSize(-21);
     }
 
@@ -447,10 +436,14 @@ class Services_LibravatarTest extends PHPUnit_Framework_TestCase
 
     protected function loadSLMock()
     {
-        $this->sl = $this->getMock('Services_Libravatar', array('srvGet'));
+        $this->sl = $this
+            ->getMockBuilder('Services_Libravatar')
+            ->onlyMethods(array('srvGet'))
+            ->getMock();
+        //$this->sl = $this->getMock('Services_Libravatar', array('srvGet'));
         $this->sl->expects($this->once())
             ->method('srvGet')
-            ->will($this->returnValue('example.org'));
+            ->willReturn('example.org');
     }
 }
 


### PR DESCRIPTION
Here is an attempt to fix https://pear.php.net/bugs/bug.php?id=21095

In my case I was getting
```
count(): Argument #1 ($value) must be of type Countable|array, false given [/var/www/vendor/pear/services_libravatar/Services/Libravatar.php:430]
```

I wasn't able to add a new unit test for that due to `Fatal error:  Cannot redeclare dns_get_record()` (php 8)